### PR TITLE
fix(lighting): fix muzzle flash not appearing on dedicated servers

### DIFF
--- a/src/main/kotlin/com/atsuishio/superbwarfare/client/lighting/ClientLightingHandler.kt
+++ b/src/main/kotlin/com/atsuishio/superbwarfare/client/lighting/ClientLightingHandler.kt
@@ -1,5 +1,6 @@
 package com.atsuishio.superbwarfare.client.lighting
 
+import com.atsuishio.superbwarfare.Mod
 import com.atsuishio.superbwarfare.entity.projectile.IBulletProperties
 import net.minecraft.client.Minecraft
 import net.minecraft.world.entity.Entity
@@ -29,42 +30,80 @@ object ClientLightingHandler {
      * Called every client tick from {@code ProjectileEntity} and
      * {@code FastThrowableProjectile#tick()}.
      *
+     * <p>Muzzle flash emission lives in {@link #handleProjectileAdded} — this
+     * method only maintains the flight trail light.
+     *
      * @param entity the projectile entity being ticked
      */
     @JvmStatic
     fun handleProjectileTick(entity: Entity) {
-        if (entity.tickCount == 1) {
-            val owner = (entity as? Projectile)?.owner
-            val localPlayer = Minecraft.getInstance().player
+        ProjectileLightHelper.emitTrailLight(entity)
+    }
 
-            if (owner !== localPlayer && owner is LivingEntity) {
-                val params = MuzzleFlashHelper.calculateFromOwner(owner)
+    /**
+     * Called when a projectile entity is added to the client world.
+     *
+     * <p>This hook is used instead of {@code tickCount == 1} because fast projectiles
+     * (e.g. sniper bullets) are frequently spawned and removed by the server within
+     * the same client packet batch. In that case the entity is added and removed
+     * without ever being ticked, so tick-based flash emission is silently skipped.
+     * {@code onAddedToWorld()} is guaranteed to fire exactly once for every
+     * projectile the client ever sees.
+     *
+     * <p>Ordering guarantees at this point ({@code ClientPacketListener.handleAddEntity}):
+     * <ul>
+     *   <li>{@code Projectile.recreateFromPacket} has already resolved the owner
+     *       from the spawn packet's data field — {@code getOwner()} is reliable.</li>
+     *   <li>The owner's equipment was synced while the client was tracking them,
+     *       so {@code mainHandItem} is valid for any visible shooter.</li>
+     *   <li>{@code SynchedEntityData} has NOT been applied yet — do not read
+     *       entity data accessors here.</li>
+     * </ul>
+     *
+     * @param entity the projectile that was just added to the client world
+     */
+    @JvmStatic
+    fun handleProjectileAdded(entity: Entity) {
+        val owner = (entity as? Projectile)?.owner
+        val localPlayer = Minecraft.getInstance().player
 
-                // Use deltaMovement if available, otherwise use the owner's look angle
+        // Mod.LOGGER.info(
+        //     "[FlashLight] added: id={} type={} tickCount={} owner={} isLocal={} pos={}",
+        //     entity.id,
+        //     entity.type.description.string,
+        //     entity.tickCount,
+        //     owner?.name?.string ?: "NULL",
+        //     owner === localPlayer,
+        //     entity.position()
+        // )
+
+        // Muzzle flash for other players' shots
+        if (owner !== localPlayer && owner is LivingEntity) {
+            val params = MuzzleFlashHelper.calculateFromOwner(owner)
+
+            if (params != null) {
+                // Spawn-packet velocity is clamped to ±3.9 blocks/tick, so fast
+                // bullets may have unreliable deltaMovement here — fall back to
+                // the owner's look angle in that case
                 val direction = if (entity.deltaMovement.lengthSqr() > 1e-6) {
                     entity.deltaMovement
                 } else {
                     owner.lookAngle
                 }
-
-                if (params != null) {
-                    MuzzleFlashHelper.spawnFlashCone(entity.position(), direction, params)
-                }
-            }
-
-            val launchFlash = ProjectileLightHelper.getLaunchFlash(entity)
-            if (launchFlash != null) {
-                val direction = if (entity.deltaMovement.lengthSqr() > 1e-6) {
-                    entity.deltaMovement
-                } else {
-                    (entity as? Projectile)
-                        ?.owner?.lookAngle ?: entity.deltaMovement
-                }
-                MuzzleFlashHelper.spawnFlashCone(entity.position(), direction, launchFlash)
+                MuzzleFlashHelper.spawnFlashCone(entity.position(), direction, params)
             }
         }
 
-        ProjectileLightHelper.emitTrailLight(entity)
+        // Launch backblast for rockets and large shells
+        val launchFlash = ProjectileLightHelper.getLaunchFlash(entity)
+        if (launchFlash != null) {
+            val direction = if (entity.deltaMovement.lengthSqr() > 1e-6) {
+                entity.deltaMovement
+            } else {
+                (entity as? Projectile)?.owner?.lookAngle ?: entity.deltaMovement
+            }
+            MuzzleFlashHelper.spawnFlashCone(entity.position(), direction, launchFlash)
+        }
     }
 
     /**

--- a/src/main/kotlin/com/atsuishio/superbwarfare/client/lighting/LightPositionRegistry.kt
+++ b/src/main/kotlin/com/atsuishio/superbwarfare/client/lighting/LightPositionRegistry.kt
@@ -91,14 +91,28 @@ object LightPositionRegistry {
     fun isEmpty(): Boolean = active.isEmpty()
 
     /**
-     * Advances the internal tick counter and removes expired sources.
-     * Forcefully updates the lighting engine on expired block positions to prevent ghost lighting.
+     * Advances the internal tick counter, refreshes active light sources, and
+     * removes expired ones.
+     *
+     * <p>Active sparks get a fresh {@code checkBlock} call every tick so the
+     * lighting engine never has a chance to serve a stale cached value.
+     * A single {@code checkBlock} at spawn time is not enough — the engine
+     * queues updates internally, and by the time it processes the queue the
+     * spark may already have a lower level or may have expired entirely.
+     * Calling {@code checkBlock} every tick keeps the value authoritative for
+     * the entire lifetime of the spark, regardless of engine scheduling.
+     *
+     * <p>Expired sparks receive one final {@code checkBlock} so the engine
+     * clears the cached non-zero emission and restores the block's natural
+     * light level.
      */
     @JvmStatic
     fun tick() {
         currentTick++
         if (sparks.isEmpty()) return
 
+        val level = Minecraft.getInstance().level ?: return
+        val engine = level.lightEngine
         expiredBuf.clear()
         val curLow = currentTick and 0xFFFFL
 
@@ -108,18 +122,24 @@ object LightPositionRegistry {
             val expiryLow = packed and 0xFFFFL
             val total = (expiryLow - startLow) and 0xFFFFL
             val elapsed = (curLow - startLow) and 0xFFFFL
-            if (elapsed > total) expiredBuf.add(entry.longKey)
+
+            if (elapsed > total) {
+                expiredBuf.add(entry.longKey)
+            } else {
+                // Re-queue a lighting check every tick while the spark is alive.
+                // Without this, the engine may serve a cached value from before
+                // the spark was registered, making the flash invisible.
+                engine.checkBlock(BlockPos.of(entry.longKey))
+            }
         }
 
         if (!expiredBuf.isEmpty) {
-            val level = Minecraft.getInstance().level
-            val engine = level?.lightEngine
             for (i in expiredBuf.indices) {
                 val key = expiredBuf.getLong(i)
                 sparks.remove(key)
                 active.remove(key)
-                // Force a final lighting recalculation on the expired block to clean up the dynamic light
-                engine?.checkBlock(BlockPos.of(key))
+                // Final check forces the engine to clear the cached emission value
+                engine.checkBlock(BlockPos.of(key))
             }
             expiredBuf.clear()
         }

--- a/src/main/kotlin/com/atsuishio/superbwarfare/client/lighting/MuzzleFlashHelper.kt
+++ b/src/main/kotlin/com/atsuishio/superbwarfare/client/lighting/MuzzleFlashHelper.kt
@@ -1,5 +1,6 @@
 package com.atsuishio.superbwarfare.client.lighting
 
+import com.atsuishio.superbwarfare.Mod
 import com.atsuishio.superbwarfare.config.client.DisplayConfig
 import com.atsuishio.superbwarfare.data.gun.GunData
 import com.atsuishio.superbwarfare.data.gun.GunProp

--- a/src/main/kotlin/com/atsuishio/superbwarfare/entity/projectile/FastThrowableProjectile.kt
+++ b/src/main/kotlin/com/atsuishio/superbwarfare/entity/projectile/FastThrowableProjectile.kt
@@ -787,13 +787,11 @@ abstract class FastThrowableProjectile : ThrowableItemProjectile, IFastMotionSyn
         this.xRotO = this.xRot
     }
 
-    companion object {
-        @JvmField
-        val SYNCED_TICK: EntityDataAccessor<Int> =
-            SynchedEntityData.defineId(FastThrowableProjectile::class.java, EntityDataSerializers.INT)
-
-        var playFlySound: Consumer<FastThrowableProjectile> = Consumer { }
-        var playNearFlySound: Consumer<FastThrowableProjectile> = Consumer { }
+    override fun onAddedToWorld() {
+        super.onAddedToWorld()
+        if (level().isClientSide) {
+            ClientLightingHandler.handleProjectileAdded(this)
+        }
     }
 
     override fun onRemovedFromWorld() {
@@ -801,6 +799,15 @@ abstract class FastThrowableProjectile : ThrowableItemProjectile, IFastMotionSyn
         if (level().isClientSide) {
             ClientLightingHandler.handleProjectileRemoved(this)
         }
+    }
+
+    companion object {
+        @JvmField
+        val SYNCED_TICK: EntityDataAccessor<Int> =
+            SynchedEntityData.defineId(FastThrowableProjectile::class.java, EntityDataSerializers.INT)
+
+        var playFlySound: Consumer<FastThrowableProjectile> = Consumer { }
+        var playNearFlySound: Consumer<FastThrowableProjectile> = Consumer { }
     }
 
     /** 独立于原版 tickCount 的计时器，每 tick +1，通过 EntityData 持久化同步 */

--- a/src/main/kotlin/com/atsuishio/superbwarfare/entity/projectile/ProjectileEntity.kt
+++ b/src/main/kotlin/com/atsuishio/superbwarfare/entity/projectile/ProjectileEntity.kt
@@ -892,6 +892,13 @@ open class ProjectileEntity(entityType: EntityType<out ProjectileEntity>, level:
         }
     }
 
+    override fun onAddedToWorld() {
+        super.onAddedToWorld()
+        if (level().isClientSide) {
+            ClientLightingHandler.handleProjectileAdded(this)
+        }
+    }
+
     /**
      * Builders
      */


### PR DESCRIPTION
Two issues caused dynamic light flashes to be intermittently invisible
for other players on dedicated servers (worked fine on localhost):

1. **Fast projectiles skipped flash entirely** — flash was emitted at
   `tickCount == 1`, but bullets are often spawned and removed within the
   same client packet batch, so `tick()` never runs. Moved to
   `onAddedToWorld()` which is guaranteed to fire once per entity.

2. **Light engine read stale values** — `checkBlock()` only enqueues an
   update. By the time the engine processes the queue, short-lived sparks
   had already expired. Now `LightPositionRegistry.tick()` re-queues
   `checkBlock` every tick for all active sparks.