### PR TITLE
Fix parallel ticking compatibility

### DIFF
--- a/src/main/kotlin/com/atsuishio/superbwarfare/entity/vehicle/base/VehicleEntity.kt
+++ b/src/main/kotlin/com/atsuishio/superbwarfare/entity/vehicle/base/VehicleEntity.kt
@@ -2217,8 +2217,9 @@ open class VehicleEntity(pEntityType: EntityType<*>, pLevel: Level) : Entity(pEn
         val maxZ = Mth.ceil(obbAABB.maxZ)
 
         for (x in minX until maxX) {
-            for (y in minY until maxY) {
-                for (z in minZ until maxZ) {
+            for (z in minZ until maxZ) {
+                if (!level.hasChunk(x shr 4, z shr 4)) continue
+                for (y in minY until maxY) {
                     val pos = BlockPos(x, y, z)
                     val fluidState = level.getFluidState(pos)
                     if (!fluidState.isEmpty) {


### PR DESCRIPTION
Vehicle fluid checks can request unloaded chunks when a collision box crosses a chunk edge. This makes Tessellate fall back to serial ticking.

This change checks whether a chunk is loaded before reading its fluid state. Fluid checks in loaded chunks are unchanged, so normal vehicle behavior stays the same.

Tested with 480 entities across two regions. Tessellate remained parallel with no unavailable chunk reads or ownership violations.